### PR TITLE
Add live balance and rating updates

### DIFF
--- a/main.js
+++ b/main.js
@@ -1487,6 +1487,20 @@ function connectSocket() {
   socket.on('chat message', msg => {
     appendChatMessage(msg);
   });
+
+  socket.on('balance update', data => {
+    if (typeof data.balance === 'number') {
+      balance = data.balance;
+      updateBalanceUI();
+    }
+  });
+
+  socket.on('rating update', data => {
+    if (typeof data.rating === 'number') {
+      rating = data.rating;
+      updateRatingUI();
+    }
+  });
 }
 
 function appendChatMessage(msg) {
@@ -1564,6 +1578,9 @@ async function saveBalance(change = 0, reason = '') {
     sendHistory('balance', change, reason);
   }
   updateBalanceUI();
+  if (socket) {
+    socket.emit('balance update', { balance });
+  }
   await saveGameData();
 }
 
@@ -1573,6 +1590,9 @@ async function saveRating(change = 0, reason = '') {
     sendHistory('rating', change, reason);
   }
   updateRatingUI();
+  if (socket) {
+    socket.emit('rating update', { rating });
+  }
   await saveGameData();
 }
 
@@ -3921,6 +3941,7 @@ async function getNearbyOSMFeatures() {
 }
 
 async function init() {
+  connectSocket();
   await flushPendingSave();
   loadCartFromStorage();
   await loadCallTypes(); // загружаем calls.json

--- a/server.js
+++ b/server.js
@@ -15,6 +15,18 @@ app.use(express.static(__dirname + '/public'));
 
 io.on('connection', (socket) => {
   console.log('🔌 Новое подключение');
+
+  socket.on('chat message', (msg) => {
+    socket.broadcast.emit('chat message', msg);
+  });
+
+  socket.on('balance update', (data) => {
+    socket.broadcast.emit('balance update', data);
+  });
+
+  socket.on('rating update', (data) => {
+    socket.broadcast.emit('rating update', data);
+  });
 });
 
 const PORT = 3000;


### PR DESCRIPTION
## Summary
- broadcast chat messages and game data updates via socket.io
- listen for balance and rating changes on client
- emit balance/rating updates when values change
- connect socket on page init

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f922135f0832bb5910de4bc7813d6